### PR TITLE
Add HWG023WRF hub + HTV213/214 (model 288) with hex-TLV decode + control_zone + refresh_token

### DIFF
--- a/homgarapi/api.py
+++ b/homgarapi/api.py
@@ -148,6 +148,7 @@ class HomgarApi:
                 product_key=dev_data.get('productKey'),
                 iot_id=dev_data.get('iotId'),
                 sid=dev_data.get('sid'),
+                port_describe=dev_data.get('portDescribe'),
             )
 
         def get_device_class(dev_data):

--- a/homgarapi/api.py
+++ b/homgarapi/api.py
@@ -84,6 +84,36 @@ class HomgarApi:
         self.cache['token_expires'] = datetime.utcnow().timestamp() + data.get('tokenExpired')
         self.cache['refresh_token'] = data.get('refreshToken')
 
+    def refresh_token(self) -> None:
+        """
+        Exchange the cached refresh token for a fresh access token.
+
+        Avoids re-logging in (which kicks the account off its phones).
+        Mirrors ``HomgarClient.refreshToken`` in the RainPoint Home APK.
+        """
+        rt = self.cache.get('refresh_token')
+        if not rt:
+            raise HomgarApiException(-1, "No refresh_token in cache; call login() first")
+        data = self._post_json(
+            "/auth/basic/app/token/refresh",
+            {"refreshToken": rt},
+            with_auth=False,
+        )
+        self.cache['token'] = data.get('token')
+        self.cache['token_expires'] = (
+            datetime.utcnow().timestamp() + data.get('tokenExpired', 0)
+        )
+        # Some deployments rotate the refresh token too.
+        if data.get('refreshToken'):
+            self.cache['refresh_token'] = data['refreshToken']
+
+    def logout(self) -> None:
+        """POST /auth/basic/app/logOut. Invalidates the access token."""
+        self._post_json("/auth/basic/app/logOut", {})
+        self.cache.pop('token', None)
+        self.cache.pop('token_expires', None)
+        self.cache.pop('refresh_token', None)
+
     def get_homes(self) -> List[HomgarHome]:
         """
         Retrieves all HomgarHome objects associated with the logged in account.
@@ -114,6 +144,10 @@ class HomgarApi:
                 address=dev_data.get('addr'),
                 port_number=dev_data.get('portNumber'),
                 alerts=dev_data.get('alerts'),
+                device_name=dev_data.get('deviceName'),
+                product_key=dev_data.get('productKey'),
+                iot_id=dev_data.get('iotId'),
+                sid=dev_data.get('sid'),
             )
 
         def get_device_class(dev_data):
@@ -158,6 +192,58 @@ class HomgarApi:
             device = id_map.get(subdevice_status['id'])
             if device is not None:
                 device.set_device_status(subdevice_status)
+
+    def control_zone(
+        self,
+        hub: HomgarHubDevice,
+        sub_addr: int,
+        port: int,
+        mode: int,
+        duration: int,
+    ) -> dict:
+        """
+        Send a manual control command to one zone/port of a sub-device.
+
+        :param hub: The hub (``HomgarHubDevice``) that the sub-device is paired
+            with — supplies ``mid``, ``deviceName`` and ``productKey``.
+        :param sub_addr: Sub-device RF address (``addr`` on a subdevice,
+            ``1`` for most users' only timer).
+        :param port: 1-based port number. 2-zone timer: 1=Sprinklers, 2=Dripline.
+        :param mode: 0 = off/cancel, 1 = manual on, 2 = scheduled.
+        :param duration: Run duration in seconds. The RainPoint Home UI
+            enforces a 60 s minimum — below that the valve + pump take
+            a beating without delivering meaningful water.
+        :return: Decoded ``data`` field of the response — includes the new
+            device status string under ``state`` and a ``timestamp``.
+
+        Mirrors ``HomgarClient.setDeviceMode`` — the server relays the
+        command to the device via Aliyun IoT Link. No MQTT client required
+        on our side.
+        """
+        # We need ``productKey`` and ``deviceName`` off the hub, which come
+        # from ``getDeviceByHid``. ``get_devices_for_hid`` already unpacks
+        # those into the base props but they're not exposed on the class
+        # — fetch from the cache dict the caller set, falling back to
+        # attributes we might add later.
+        device_name = getattr(hub, "device_name", None) or hub.__dict__.get("deviceName")
+        product_key = getattr(hub, "product_key", None) or hub.__dict__.get("productKey")
+        if not device_name or not product_key:
+            raise HomgarApiException(
+                -1,
+                "Hub is missing deviceName/productKey — did you call "
+                "get_devices_for_hid() first?",
+            )
+        body = {
+            "deviceName": device_name,
+            "productKey": product_key,
+            "mid": str(hub.mid),
+            "addr": sub_addr,
+            "port": port,
+            "mode": mode,
+            "duration": duration,
+            "param": "",
+        }
+        return self._post_json("/app/device/controlWorkMode", body)
 
     def ensure_logged_in(self, email: str, password: str, area_code: str = "31") -> None:
         """

--- a/homgarapi/api.py
+++ b/homgarapi/api.py
@@ -44,9 +44,22 @@ class HomgarApi:
         self.cache = auth_cache or {}
         self.base = api_base_url
 
+    #: Headers the current RainPoint Home app (1.16.1057) sends with every
+    #: authenticated request. `appCode=2` replaced `appCode=1` on newer
+    #: firmware — the server rejects `appCode=1` logins from some accounts
+    #: with `code 2001 "Wrong account or password"` even when the password
+    #: is correct. The `version` and `sceneType` values were captured from
+    #: the app and treated as opaque client-identification headers.
+    DEFAULT_HEADERS = {
+        "lang": "en",
+        "appCode": "2",
+        "version": "1.16.1057",
+        "sceneType": "1",
+    }
+
     def _request(self, method, url, with_auth=True, headers=None, **kwargs):
         logger.log(TRACE, "%s %s %s", method, url, kwargs)
-        headers = {"lang": "en", "appCode": "1", **(headers or {})}
+        headers = {**self.DEFAULT_HEADERS, **(headers or {})}
         if with_auth:
             headers["auth"] = self.cache["token"]
         response = self.session.request(method, url, headers=headers, **kwargs)

--- a/homgarapi/api.py
+++ b/homgarapi/api.py
@@ -57,11 +57,17 @@ class HomgarApi:
         "sceneType": "1",
     }
 
+    # (connect, read) seconds. Without an explicit timeout, a half-open
+    # TCP connection from the HomGar cloud can block the caller forever —
+    # in a DataUpdateCoordinator that means no further polls ever fire.
+    DEFAULT_TIMEOUT = (10, 30)
+
     def _request(self, method, url, with_auth=True, headers=None, **kwargs):
         logger.log(TRACE, "%s %s %s", method, url, kwargs)
         headers = {**self.DEFAULT_HEADERS, **(headers or {})}
         if with_auth:
             headers["auth"] = self.cache["token"]
+        kwargs.setdefault("timeout", self.DEFAULT_TIMEOUT)
         response = self.session.request(method, url, headers=headers, **kwargs)
         logger.log(TRACE, "-[%03d]-> %s", response.status_code, response.text)
         return response

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -278,10 +278,23 @@ class HomgarSubDevice(HomgarDevice):
         self.port_describe_raw = port_describe or ""
 
     def port_label(self, port: int) -> str:
-        """Return the user-set label for a port (1-based), or 'Port N'."""
+        """Return the user-set label for a port (1-based), or a fallback.
+
+        Fallback rules:
+          * Multi-port device (port_number > 1): ``"Port N"`` so each
+            port is distinguishable in HA's UI.
+          * Single-port device (port_number == 1) with no portDescribe:
+            empty string. Callers can check truthiness to decide between
+            "render as device-only" (e.g. a switch) and "drop the
+            redundant prefix" (e.g. ``f"{label} running".strip()``).
+            Single-port devices in the wild (HTV113FRF) often surface
+            their identity at the device level only.
+        """
         labels = [p for p in self.port_describe_raw.split("|") if p]
         if 1 <= port <= len(labels):
             return labels[port - 1]
+        if self.port_number == 1:
+            return ""
         return f"Port {port}"
 
     def __str__(self):

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -639,13 +639,46 @@ class RainPoint2ZoneTimer_V2(HomgarSubDevice):
 class RainPointDisplayHubV2(HomgarHubDevice):
     """Newer irrigation hub (HWG023WRF, model 273).
 
-    The hub itself doesn't carry irrigation state — sub-devices do. This class
-    exists mainly so that ``getDeviceByHid`` can produce the right hub type
-    and so downstream HA code can identify the hub model.
+    The hub carries no irrigation state of its own — sub-devices do that
+    — but it does report its own Wi-Fi RSSI, internal battery-backup
+    state and connectivity flag via the non-``Dxx`` entries in
+    ``/getDeviceStatus``.
+
+    Observed entries:
+      * ``state``      — ``"<battery_state>,<wifi_rssi_dbm>"`` e.g. ``"0,-81"``
+      * ``connected``  — ``"1"`` while the hub is online, ``"0"`` otherwise
+
+    HWG023WRF is mains-powered so ``battery_state`` is usually 0; it's
+    still exposed in case a different revision populates it.
     """
 
     MODEL_CODES = [273]
     FRIENDLY_DESC = "Smart+ Irrigation Hub (HWG023WRF)"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.wifi_rssi: Optional[int] = None
+        self.battery_state: Optional[int] = None
+        self.connected: Optional[bool] = None
+
+    def get_device_status_ids(self) -> List[str]:
+        return ["state", "connected"]
+
+    def set_device_status(self, api_obj: dict) -> None:
+        dev_id = api_obj.get('id')
+        val = api_obj.get('value')
+        if val is None:
+            return
+        if dev_id == "state":
+            try:
+                self.battery_state, self.wifi_rssi = [int(s) for s in val.split(',')]
+            except (ValueError, AttributeError):
+                pass
+        elif dev_id == "connected":
+            try:
+                self.connected = int(val) == 1
+            except (ValueError, TypeError):
+                pass
 
 
 MODEL_CODE_MAPPING = {

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -1,7 +1,110 @@
 import re
-from typing import List
+import struct
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
 
 STATS_VALUE_REGEX = re.compile(r'^(\d+)\((\d+)/(\d+)/(\d+)\)')
+
+
+# ---------------------------------------------------------------------------
+# Hex-packed binary TLV decoder for newer firmwares (paramVersion >= ~16).
+#
+# Reverse-engineered from the RainPoint Home APK
+# (com.baldr.homgar.bean.DpDeviceStatus.analyzeDpDeviceStatus). The value
+# looks like "<firmware>#<hex bytes>" with no leading general-status ';'.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DpRecord:
+    """One TLV record from a Dxx status value."""
+    dp_id: int          # e.g. 25 = STA_WKSTATE port 1 on HTV213FRF/model-288
+    type_code: int      # the dpCode from the productModel catalog
+    type_len: int       # number of payload data bytes (excluding header)
+    payload: bytes      # the payload bytes proper
+
+
+def parse_tlv_d_value(value: str) -> List[DpRecord]:
+    """Parse a single ``Dxx`` status value in the hex-packed TLV format.
+
+    The string ``"11#17E1C2..."`` is composed of an ASCII firmware-version
+    prefix (``11``), a ``#`` separator and the binary payload encoded as hex.
+    Each record is 1 byte of ``dpId`` followed by either:
+
+    * SHORT form (top bit clear): 1 byte header whose bits 6..4 are the
+      ``typeCode`` and whose bits 3..0 are the sole data nibble.
+    * LONG form (top bit set):
+        ``i15 = (h >> 2) & 0x1F`` (extended when 31),
+        ``i16 = h & 3`` → ``typeLen = i16 + 1``,
+        typeCode = ``i15 + 8`` (or ``buf[next] + 39`` when extended),
+        payload spans ``typeLen`` bytes after the header byte.
+
+    Anything after the first ``,`` is ignored — that's a legacy hook the
+    older format used.
+    """
+    comma = value.find(",")
+    if comma != -1:
+        value = value[:comma]
+    if "#" in value:
+        # Strip "<2 chars>#", e.g. "11#".
+        value = value[3:]
+    buf = bytes.fromhex(value)
+
+    out: List[DpRecord] = []
+    i = 0
+    n = len(buf)
+    while i < n:
+        dp_id = buf[i]
+        i += 1
+        if i >= n:
+            break
+        header = buf[i]
+        if (header >> 7) & 1 == 0:
+            # SHORT: single byte, payload is the low nibble.
+            type_code = (header >> 4) & 7
+            payload = bytes([header & 0x0F])
+            type_len = 1
+            i += 1
+        else:
+            i15 = (header >> 2) & 0x1F
+            i16 = header & 3
+            type_len = i16 + 1
+            span = i16 + 2  # header + type_len bytes (overlapping on some)
+            if i15 <= 30:
+                type_code = i15 + 8
+                payload = buf[i + 1:i + span]
+                i += span
+            else:
+                # extended code — next byte is the type code offset
+                i += 1
+                if i >= n:
+                    break
+                type_code = buf[i] + 39
+                payload = buf[i + 1:i + span]
+                i += span
+        out.append(DpRecord(dp_id=dp_id, type_code=type_code,
+                             type_len=type_len, payload=payload))
+    return out
+
+
+def _to_int_le(payload: bytes, signed: bool = False) -> int:
+    if not payload:
+        return 0
+    n = len(payload)
+    if signed:
+        if n == 1:
+            return struct.unpack("<b", payload[:1])[0]
+        if n == 2:
+            return struct.unpack("<h", payload[:2])[0]
+        if n == 4:
+            return struct.unpack("<i", payload[:4])[0]
+        return int.from_bytes(payload, "little", signed=True)
+    if n == 1:
+        return payload[0]
+    if n == 2:
+        return struct.unpack("<H", payload[:2])[0]
+    if n == 4:
+        return struct.unpack("<I", payload[:4])[0]
+    return int.from_bytes(payload, "little")
 
 
 def _parse_stats_value(s):
@@ -33,13 +136,23 @@ class HomgarDevice:
 
     FRIENDLY_DESC = "Unknown HomGar device"
 
-    def __init__(self, model, model_code, name, did, mid, alerts, **kwargs):
+    def __init__(self, model, model_code, name, did, mid, alerts,
+                 device_name=None, product_key=None, iot_id=None, sid=None,
+                 **kwargs):
         self.model = model
         self.model_code = model_code
         self.name = name
         self.did = did  # the unique device identifier of this device itself
         self.mid = mid  # the unique identifier of the sensor network
         self.alerts = alerts
+
+        # Identifiers needed for the control endpoint. Only hubs populate
+        # device_name/product_key but we accept them on all classes so they
+        # flow through kwargs cleanly from get_devices_for_hid.
+        self.device_name = device_name
+        self.product_key = product_key
+        self.iot_id = iot_id
+        self.sid = sid
 
         self.address = None
         self.rf_rssi = None
@@ -286,6 +399,7 @@ class RainPointAirSensor(HomgarSubDevice):
 
 
 class RainPoint2ZoneTimer(HomgarSubDevice):
+    """Legacy 2-Zone Water Timer (paramVersion=2 comma-separated format)."""
     MODEL_CODES = [261]
     FRIENDLY_DESC = "2-Zone Water Timer"
 
@@ -302,13 +416,151 @@ class RainPoint2ZoneTimer(HomgarSubDevice):
         pass
 
 
+# ---------------------------------------------------------------------------
+# Newer-firmware devices: hub HWG023WRF and 2-zone timer HTV213FRF /
+# HTV214FRF (model 288) both use the hex-packed TLV status format and do
+# NOT emit the legacy `<general>;<specific>` prefix.
+# ---------------------------------------------------------------------------
+
+
+# dpCode (aka typeCode) for known identities on HTV213FRF/HTV214FRF, model
+# 288. Per-port statuses come in as records with typeCode==dp_code and
+# dp_id matching the port-specific entry in the productModel catalog.
+_HTV213_DP_CODES = {
+    "STA_RSSI": 32,
+    "STA_BAT": 31,
+    "STA_WKSTATE": 30,
+    "STA_ALARM": 2,
+    "STA_EVTIME": 21,
+    "STA_DURATION": 19,
+    "STA_LASTUSAGE": 15,
+}
+
+# Per-port dpIds for the 2-zone timer (model 288). Port 1 = Sprinklers,
+# port 2 = Dripline by default (from portDescribe in the API).
+_HTV213_PORT_DP_IDS = {
+    1: {
+        "STA_WKSTATE": 25,
+        "STA_ALARM": 29,
+        "STA_EVTIME": 33,
+        "STA_DURATION": 37,
+        "STA_LASTUSAGE": 41,
+    },
+    2: {
+        "STA_WKSTATE": 26,
+        "STA_ALARM": 30,
+        "STA_EVTIME": 34,
+        "STA_DURATION": 38,
+        "STA_LASTUSAGE": 42,
+    },
+}
+
+
+@dataclass
+class ZonePortStatus:
+    """Per-zone state for a multi-port irrigation timer."""
+    port: int
+    wkstate: Optional[int] = None          # bit0=running, other bits flags
+    alarm: Optional[int] = None
+    ev_time: Optional[int] = None          # device-relative event-start
+    duration_s: Optional[int] = None       # requested run duration (seconds)
+    last_usage_dl: Optional[int] = None    # last-cycle usage, units 0.1 L
+
+    @property
+    def running(self) -> bool:
+        return bool(self.wkstate and self.wkstate & 1)
+
+
+class RainPoint2ZoneTimer_V2(HomgarSubDevice):
+    """2-Zone Water Timer on paramVersion>=16 firmware (hex TLV format).
+
+    Models 288 (HTV214FRF / shown as HTV213FRF) and 261 (older HTV213FRF)
+    on new firmware. Port 1 is the 'first' hose output, port 2 the second.
+    """
+
+    MODEL_CODES = [288]
+    FRIENDLY_DESC = "2-Zone Water Timer (v2)"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.battery_state: Optional[int] = None
+        self.ports: Dict[int, ZonePortStatus] = {
+            1: ZonePortStatus(port=1),
+            2: ZonePortStatus(port=2),
+        }
+        # This device sends its D value without the legacy ';' general prefix,
+        # so we override the general RSSI capture from the TLV stream.
+
+    def _parse_status_d_value(self, val: str) -> None:
+        """Override: new firmware sends the TLV blob directly with no ';'."""
+        records = parse_tlv_d_value(val)
+        for rec in records:
+            self._apply_record(rec)
+
+    def _apply_record(self, rec: DpRecord) -> None:
+        # Shared (non-port-scoped) codes
+        if rec.type_code == _HTV213_DP_CODES["STA_RSSI"]:
+            # 2 bytes come through; firmware treats low byte as signed dBm.
+            self.rf_rssi = _to_int_le(rec.payload[:1], signed=True)
+            return
+        if rec.type_code == _HTV213_DP_CODES["STA_BAT"]:
+            self.battery_state = _to_int_le(rec.payload, signed=False)
+            return
+
+        # Per-port codes — resolve port via dpId lookup
+        for port, ids in _HTV213_PORT_DP_IDS.items():
+            if rec.dp_id != ids.get(self._identity_for(rec.type_code)):
+                continue
+            status = self.ports[port]
+            ident = self._identity_for(rec.type_code)
+            if ident == "STA_WKSTATE":
+                status.wkstate = _to_int_le(rec.payload)
+            elif ident == "STA_ALARM":
+                status.alarm = _to_int_le(rec.payload)
+            elif ident == "STA_EVTIME":
+                status.ev_time = _to_int_le(rec.payload)
+            elif ident == "STA_DURATION":
+                status.duration_s = _to_int_le(rec.payload)
+            elif ident == "STA_LASTUSAGE":
+                status.last_usage_dl = _to_int_le(rec.payload)
+            return
+
+    @staticmethod
+    def _identity_for(type_code: int) -> Optional[str]:
+        for name, code in _HTV213_DP_CODES.items():
+            if code == type_code:
+                return name
+        return None
+
+    def __str__(self) -> str:
+        tail = []
+        for port, s in self.ports.items():
+            state = "RUN" if s.running else "idle"
+            tail.append(f"p{port}={state}/d={s.duration_s}s/u={s.last_usage_dl}")
+        return f"{super().__str__()} [{', '.join(tail)}]"
+
+
+class RainPointDisplayHubV2(HomgarHubDevice):
+    """Newer irrigation hub (HWG023WRF, model 273).
+
+    The hub itself doesn't carry irrigation state — sub-devices do. This class
+    exists mainly so that ``getDeviceByHid`` can produce the right hub type
+    and so downstream HA code can identify the hub model.
+    """
+
+    MODEL_CODES = [273]
+    FRIENDLY_DESC = "Smart+ Irrigation Hub (HWG023WRF)"
+
+
 MODEL_CODE_MAPPING = {
     code: clazz
     for clazz in (
         RainPointDisplayHub,
+        RainPointDisplayHubV2,
         RainPointSoilMoistureSensor,
         RainPointRainSensor,
         RainPointAirSensor,
-        RainPoint2ZoneTimer
+        RainPoint2ZoneTimer,
+        RainPoint2ZoneTimer_V2,
     ) for code in clazz.MODEL_CODES
 }

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -568,11 +568,12 @@ class ZonePortStatus:
 
 
 class RainPoint2ZoneTimer_V2(HomgarSubDevice):
-    """N-Zone Water Timer on paramVersion>=16 firmware (hex TLV format).
+    """2-Zone Water Timer on paramVersion>=16 firmware (hex TLV format).
 
-    Model 288 (HTV214FRF / shown as HTV213FRF) is the 2-zone variant.
-    Subclasses override PORT_COUNT / PORT_DP_IDS / HAS_DPID_PREFIX for
-    other port counts (e.g. the HTV113FRF 1-zone valve, Task 4).
+    Model 288 (HTV214FRF / shown as HTV213FRF). Also serves as the
+    configurable base class for other port counts — subclasses override
+    PORT_COUNT / PORT_DP_IDS / HAS_DPID_PREFIX (e.g. the HTV113FRF
+    1-zone valve).
     """
 
     MODEL_CODES = [288]
@@ -585,10 +586,15 @@ class RainPoint2ZoneTimer_V2(HomgarSubDevice):
     # per record — there's no ambiguity to resolve, so the firmware drops
     # it. Multi-port timers (HTV213/214) carry a dp_id byte per record
     # so we can distinguish port 1 vs port 2 instances of the same dpCode.
+    # Invariant: ``HAS_DPID_PREFIX`` must be True when ``PORT_COUNT`` > 1.
     HAS_DPID_PREFIX = True
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        assert self.HAS_DPID_PREFIX or self.PORT_COUNT == 1, (
+            f"{type(self).__name__}: multi-port device must set HAS_DPID_PREFIX=True; "
+            "without a per-record dp_id byte, port-scoped records cannot be disambiguated."
+        )
         self.battery_state: Optional[int] = None
         self.ports: Dict[int, ZonePortStatus] = {
             p: ZonePortStatus(port=p)

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -568,33 +568,43 @@ class ZonePortStatus:
 
 
 class RainPoint2ZoneTimer_V2(HomgarSubDevice):
-    """2-Zone Water Timer on paramVersion>=16 firmware (hex TLV format).
+    """N-Zone Water Timer on paramVersion>=16 firmware (hex TLV format).
 
-    Models 288 (HTV214FRF / shown as HTV213FRF) and 261 (older HTV213FRF)
-    on new firmware. Port 1 is the 'first' hose output, port 2 the second.
+    Model 288 (HTV214FRF / shown as HTV213FRF) is the 2-zone variant.
+    Subclasses override PORT_COUNT / PORT_DP_IDS / HAS_DPID_PREFIX for
+    other port counts (e.g. the HTV113FRF 1-zone valve, Task 4).
     """
 
     MODEL_CODES = [288]
     FRIENDLY_DESC = "2-Zone Water Timer (v2)"
 
+    # --- Overridable class configuration ---
+    PORT_COUNT = 2
+    PORT_DP_IDS = _HTV213_PORT_DP_IDS
+    # Single-port timers (e.g. HTV113FRF) pack status with no dp_id byte
+    # per record — there's no ambiguity to resolve, so the firmware drops
+    # it. Multi-port timers (HTV213/214) carry a dp_id byte per record
+    # so we can distinguish port 1 vs port 2 instances of the same dpCode.
+    HAS_DPID_PREFIX = True
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.battery_state: Optional[int] = None
         self.ports: Dict[int, ZonePortStatus] = {
-            1: ZonePortStatus(port=1),
-            2: ZonePortStatus(port=2),
+            p: ZonePortStatus(port=p)
+            for p in range(1, self.PORT_COUNT + 1)
         }
 
     def _parse_device_specific_status_d_value(self, s: str):
         """Newer firmware sends hex-TLV status (``NN#<hex>...``), no ';'
         separator. The base class _parse_status_d_value passes the whole
         value through as ``s`` when there is no ';'."""
-        records = parse_tlv_d_value(s)
+        records = parse_tlv_d_value(s, has_dpid_prefix=self.HAS_DPID_PREFIX)
         for rec in records:
             self._apply_record(rec)
 
     def _apply_record(self, rec: DpRecord) -> None:
-        # Shared (non-port-scoped) codes
+        # Shared (non-port-scoped) codes — dp_id is irrelevant here.
         if rec.type_code == _HTV213_DP_CODES["STA_RSSI"]:
             # 2 bytes come through; firmware treats low byte as signed dBm.
             self.rf_rssi = _to_int_le(rec.payload[:1], signed=True)
@@ -603,23 +613,40 @@ class RainPoint2ZoneTimer_V2(HomgarSubDevice):
             self.battery_state = _to_int_le(rec.payload, signed=False)
             return
 
-        # Per-port codes — resolve port via dpId lookup
-        for port, ids in _HTV213_PORT_DP_IDS.items():
-            if rec.dp_id != ids.get(self._identity_for(rec.type_code)):
-                continue
-            status = self.ports[port]
-            ident = self._identity_for(rec.type_code)
-            if ident == "STA_WKSTATE":
-                status.wkstate = _to_int_le(rec.payload)
-            elif ident == "STA_ALARM":
-                status.alarm = _to_int_le(rec.payload)
-            elif ident == "STA_EVTIME":
-                status.ev_time = _to_int_le(rec.payload)
-            elif ident == "STA_DURATION":
-                status.duration_s = _to_int_le(rec.payload)
-            elif ident == "STA_LASTUSAGE":
-                status.last_usage_dl = _to_int_le(rec.payload)
+        # Per-port codes
+        ident = self._identity_for(rec.type_code)
+        if ident is None:
             return
+
+        if self.HAS_DPID_PREFIX:
+            # Multi-port: the dp_id byte disambiguates port 1 vs port 2
+            # instances of the same dpCode. Match on (dp_id, identity).
+            for port, ids in self.PORT_DP_IDS.items():
+                if rec.dp_id == ids.get(ident):
+                    self._apply_to_port(port, ident, rec.payload)
+                    return
+        else:
+            # Single-port: no dp_id in the wire format (rec.dp_id is 0).
+            # The identity alone tells us which port-scoped field to set;
+            # since there's only one port, apply to the first port whose
+            # PORT_DP_IDS contains this identity.
+            for port, ids in self.PORT_DP_IDS.items():
+                if ident in ids:
+                    self._apply_to_port(port, ident, rec.payload)
+                    return
+
+    def _apply_to_port(self, port: int, ident: str, payload: bytes) -> None:
+        status = self.ports[port]
+        if ident == "STA_WKSTATE":
+            status.wkstate = _to_int_le(payload)
+        elif ident == "STA_ALARM":
+            status.alarm = _to_int_le(payload)
+        elif ident == "STA_EVTIME":
+            status.ev_time = _to_int_le(payload)
+        elif ident == "STA_DURATION":
+            status.duration_s = _to_int_le(payload)
+        elif ident == "STA_LASTUSAGE":
+            status.last_usage_dl = _to_int_le(payload)
 
     @staticmethod
     def _identity_for(type_code: int) -> Optional[str]:

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -184,13 +184,34 @@ class HomgarDevice:
     def _parse_status_d_value(self, val: str) -> None:
         """
         Parses a $.data.subDeviceStatus[x].value field for an entry with ID 'Dxx' where xx is the device address.
-        These fields consist of a common part and a device-specific part separated by a ';'.
-        This call should update the device status.
+
+        Two on-wire formats in the wild:
+
+        * Legacy (paramVersion<=2): ``<general>;<specific>`` where ``<general>``
+          is ``flag,rssi,flag`` (per _parse_general_status_d_value).
+        * Newer (paramVersion>=16): no ``;`` — the whole value is the
+          device-specific blob (typically the hex-TLV format handled by
+          classes like ``RainPoint2ZoneTimer_V2``).
+
+        The parse is wrapped in a try/except so one mis-formatted sub-device
+        doesn't bring down the whole poll — status fields the subclass can't
+        decode are simply ignored.
+
         :param val: Value of the $.data.subDeviceStatus[x].value field to apply
         """
-        general_str, specific_str = val.split(';')
-        self._parse_general_status_d_value(general_str)
-        self._parse_device_specific_status_d_value(specific_str)
+        try:
+            if ';' in val:
+                general_str, specific_str = val.split(';', 1)
+                self._parse_general_status_d_value(general_str)
+            else:
+                specific_str = val
+            self._parse_device_specific_status_d_value(specific_str)
+        except Exception as e:  # noqa: BLE001 — best-effort per sub-device
+            import logging
+            logging.getLogger(__name__).debug(
+                "%s: failed to parse status value %r: %s",
+                type(self).__name__, val, e,
+            )
 
     def _parse_general_status_d_value(self, s: str):
         """
@@ -498,12 +519,12 @@ class RainPoint2ZoneTimer_V2(HomgarSubDevice):
             1: ZonePortStatus(port=1),
             2: ZonePortStatus(port=2),
         }
-        # This device sends its D value without the legacy ';' general prefix,
-        # so we override the general RSSI capture from the TLV stream.
 
-    def _parse_status_d_value(self, val: str) -> None:
-        """Override: new firmware sends the TLV blob directly with no ';'."""
-        records = parse_tlv_d_value(val)
+    def _parse_device_specific_status_d_value(self, s: str):
+        """Newer firmware sends hex-TLV status (``NN#<hex>...``), no ';'
+        separator. The base class _parse_status_d_value passes the whole
+        value through as ``s`` when there is no ';'."""
+        records = parse_tlv_d_value(s)
         for rec in records:
             self._apply_record(rec)
 

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -669,6 +669,36 @@ class RainPoint2ZoneTimer_V2(HomgarSubDevice):
         return f"{super().__str__()} [{', '.join(tail)}]"
 
 
+# Per-port dpIds for the 1-zone mains-top-up valve (model 259). From
+# productModel catalog capture 2026-04-24 (api-sniffing). Port-1 entries
+# match HTV213FRF port 1 exactly — the two devices share identities.
+_HTV113_PORT_DP_IDS = {
+    1: {
+        "STA_WKSTATE":   25,
+        "STA_ALARM":     29,
+        "STA_EVTIME":    33,
+        "STA_DURATION":  37,
+        "STA_LASTUSAGE": 41,
+    },
+}
+
+
+class RainPoint1ZoneTimer_V2(RainPoint2ZoneTimer_V2):
+    """1-Zone Water Timer on paramVersion>=16 firmware (hex TLV format).
+
+    Model 259 — HTV113FRF, a single-port valve used e.g. as a rainwater-
+    tank mains top-up. Shares all dp identities with the 2-zone model
+    but wire-formats its status with no per-record dp_id byte (the
+    ``10#`` prefix, vs the 2-zone's ``11#`` + dp_id pattern).
+    """
+
+    MODEL_CODES = [259]
+    FRIENDLY_DESC = "1-Zone Water Timer (v2)"
+    PORT_COUNT = 1
+    PORT_DP_IDS = _HTV113_PORT_DP_IDS
+    HAS_DPID_PREFIX = False
+
+
 class RainPointDisplayHubV2(HomgarHubDevice):
     """Newer irrigation hub (HWG023WRF, model 273).
 
@@ -724,5 +754,6 @@ MODEL_CODE_MAPPING = {
         RainPointAirSensor,
         RainPoint2ZoneTimer,
         RainPoint2ZoneTimer_V2,
+        RainPoint1ZoneTimer_V2,
     ) for code in clazz.MODEL_CODES
 }

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -23,12 +23,22 @@ class DpRecord:
     payload: bytes      # the payload bytes proper
 
 
-def parse_tlv_d_value(value: str) -> List[DpRecord]:
+def parse_tlv_d_value(value: str, has_dpid_prefix: bool = True) -> List[DpRecord]:
     """Parse a single ``Dxx`` status value in the hex-packed TLV format.
 
     The string ``"11#17E1C2..."`` is composed of an ASCII firmware-version
     prefix (``11``), a ``#`` separator and the binary payload encoded as hex.
-    Each record is 1 byte of ``dpId`` followed by either:
+    Each record is either:
+
+    * ``has_dpid_prefix=True`` (HTV213/214 2-zone timer on new firmware):
+      1 byte of ``dpId`` followed by a header byte — the dp_id distinguishes
+      per-port instances of the same dpCode (e.g. STA_WKSTATE on port 1 vs 2).
+    * ``has_dpid_prefix=False`` (HCS012ARF rain sensor on new firmware):
+      records are back-to-back header bytes with no dp_id prefix. The rain
+      sensor only has one instance of each dpCode so the caller can just
+      match on ``type_code``.
+
+    After the dp_id byte (if any) comes:
 
     * SHORT form (top bit clear): 1 byte header whose bits 6..4 are the
       ``typeCode`` and whose bits 3..0 are the sole data nibble.
@@ -53,10 +63,13 @@ def parse_tlv_d_value(value: str) -> List[DpRecord]:
     i = 0
     n = len(buf)
     while i < n:
-        dp_id = buf[i]
-        i += 1
-        if i >= n:
-            break
+        if has_dpid_prefix:
+            dp_id = buf[i]
+            i += 1
+            if i >= n:
+                break
+        else:
+            dp_id = 0
         header = buf[i]
         if (header >> 7) & 1 == 0:
             # SHORT: single byte, payload is the low nibble.
@@ -367,6 +380,19 @@ class RainPointSoilMoistureSensor(HomgarSubDevice):
         return s
 
 
+# Rain sensor (HCS012ARF) dpCodes from the productModel catalog. Unlike the
+# 2-zone timer, each code appears exactly once per payload so we key on
+# type_code alone.
+_HCS012_DP_CODES = {
+    "STA_RSSI": 32,
+    "STA_BAT": 31,
+    "STA_TOTAL_RAIN": 13,
+    "STA_HOUR_RAIN": 43,
+    "STA_DAY_RAIN": 44,
+    "STA_7DAY_RAIN": 45,
+}
+
+
 class RainPointRainSensor(HomgarSubDevice):
     MODEL_CODES = [87]
     FRIENDLY_DESC = "High Precision Rain Sensor"
@@ -376,22 +402,61 @@ class RainPointRainSensor(HomgarSubDevice):
         self.rainfall_mm_total = None
         self.rainfall_mm_hour = None
         self.rainfall_mm_daily = None
-        self.rainfall_mm_total = None
+        self.rainfall_mm_7days = None
+        self.battery_state: Optional[int] = None
 
     def _parse_device_specific_status_d_value(self, s):
-        """
-        Observed example value:
-        R=270(0/0/270)
+        """Auto-detect legacy ``R=...`` vs newer hex-TLV format.
 
-        Deduced meaning:
-        R=total?[.1mm](hour?[.1mm]/24hours?[.1mm]/7days?[.1mm])
+        Legacy firmware emits ``R=270(0/0/270)`` — total/hour/24h/7days in
+        0.1 mm units. Newer firmware emits ``NN#<hex>`` where ``NN`` is a
+        2-char firmware version, with records packed back-to-back (no
+        per-record dp_id prefix — rain sensor has only one instance of each
+        dpCode). See productModel.json entry for HCS012ARF (modelCode 87).
         """
-        self.rainfall_mm_total, self.rainfall_mm_hour, self.rainfall_mm_daily, self.rainfall_mm_7days = [.1*v for v in _parse_stats_value(s[2:])]
+        if s.startswith("R="):
+            self._parse_legacy_stats(s)
+        elif "#" in s:
+            self._parse_tlv_stats(s)
+
+    def _parse_legacy_stats(self, s: str) -> None:
+        """Legacy paramVersion<=2 layout:
+        ``R=total(hour/24h/7days)`` all in 0.1 mm units.
+        """
+        self.rainfall_mm_total, self.rainfall_mm_hour, self.rainfall_mm_daily, self.rainfall_mm_7days = [
+            .1 * v for v in _parse_stats_value(s[2:])
+        ]
+
+    def _parse_tlv_stats(self, s: str) -> None:
+        for rec in parse_tlv_d_value(s, has_dpid_prefix=False):
+            tc = rec.type_code
+            if tc == _HCS012_DP_CODES["STA_RSSI"]:
+                # Firmware reports the low byte as a signed dBm figure.
+                self.rf_rssi = _to_int_le(rec.payload[:1], signed=True)
+            elif tc == _HCS012_DP_CODES["STA_BAT"]:
+                # Enum per productModel: 1 = normal, 3 = low.
+                self.battery_state = _to_int_le(rec.payload)
+            elif tc == _HCS012_DP_CODES["STA_HOUR_RAIN"]:
+                self.rainfall_mm_hour = _to_int_le(rec.payload) * 0.1
+            elif tc == _HCS012_DP_CODES["STA_DAY_RAIN"]:
+                self.rainfall_mm_daily = _to_int_le(rec.payload) * 0.1
+            elif tc == _HCS012_DP_CODES["STA_7DAY_RAIN"]:
+                self.rainfall_mm_7days = _to_int_le(rec.payload) * 0.1
+            elif tc == _HCS012_DP_CODES["STA_TOTAL_RAIN"]:
+                # Running lifetime total. productModel leaves `decimal` unset
+                # but the on-wire unit matches the window counters at 0.1 mm,
+                # consistent with the legacy R=... format's total field.
+                self.rainfall_mm_total = _to_int_le(rec.payload) * 0.1
 
     def __str__(self):
         s = super().__str__()
-        if self.rainfall_mm_total:
-            s += f": {self.rainfall_mm_total}mm total / {self.rainfall_mm_hour}mm 1h / {self.rainfall_mm_daily}mm 24h / {self.rainfall_mm_7days}mm 7days"
+        if self.rainfall_mm_total is not None:
+            s += (
+                f": {self.rainfall_mm_total}mm total / "
+                f"{self.rainfall_mm_hour}mm 1h / "
+                f"{self.rainfall_mm_daily}mm 24h / "
+                f"{self.rainfall_mm_7days}mm 7days"
+            )
         return s
 
 

--- a/homgarapi/devices.py
+++ b/homgarapi/devices.py
@@ -235,10 +235,20 @@ class HomgarSubDevice(HomgarDevice):
     A subdevice is a device that is associated with a hub.
     It can be a sensor or an actuator.
     """
-    def __init__(self, address, port_number, **kwargs):
+    def __init__(self, address, port_number, port_describe=None, **kwargs):
         super().__init__(**kwargs)
         self.address = address  # device address within the sensor network
         self.port_number = port_number  # the number of ports on the device, e.g. 2 for the 2-zone water timer
+        # Pipe-separated per-port labels from /app/device/getDeviceByHid's
+        # `portDescribe` field (e.g. "Sprinklers|Dripline"). Split lazily.
+        self.port_describe_raw = port_describe or ""
+
+    def port_label(self, port: int) -> str:
+        """Return the user-set label for a port (1-based), or 'Port N'."""
+        labels = [p for p in self.port_describe_raw.split("|") if p]
+        if 1 <= port <= len(labels):
+            return labels[port - 1]
+        return f"Port {port}"
 
     def __str__(self):
         return f"{super().__str__()} at address {self.address}"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
-version = os.environ['GITHUB_REF_NAME']
+# Prefer the GitHub Actions tag when building a release, but fall back to a
+# local version so `pip install git+...` (e.g. from a Home Assistant custom
+# integration manifest) doesn't blow up outside CI.
+version = os.environ.get('GITHUB_REF_NAME') or '0.0.0+local'
 
 setup(
     name='homgarapi',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,55 @@
+"""Regression tests for the HomgarApi HTTP client itself.
+
+These guard against the exact class of failure that bricked Richard's HA
+integration on 2026-04-20: HomGar's HTTPS endpoint silently dropped a
+socket mid-response, the underlying ``requests`` call had no ``timeout``
+and blocked the coordinator's executor thread indefinitely. After that
+the DataUpdateCoordinator's in-flight update never completed and no
+further polls fired — the valve switch stayed pinned at its last polled
+state for three days.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homgarapi.api import HomgarApi
+
+
+def _api_with_mock_session(json_payload):
+    sess = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = json_payload
+    resp.text = "ok"
+    sess.request.return_value = resp
+    api = HomgarApi(auth_cache={"token": "t"}, requests_session=sess)
+    return api, sess
+
+
+def test_request_passes_a_timeout_even_when_caller_does_not_supply_one():
+    """Every _request call must be bounded. Otherwise a half-open TCP
+    connection from the HomGar cloud can hang the whole coordinator."""
+    api, sess = _api_with_mock_session({"code": 0, "data": {}})
+    api._get_json("/ping")
+    _, kwargs = sess.request.call_args
+    assert "timeout" in kwargs, "_request must pass timeout= to requests"
+    timeout = kwargs["timeout"]
+    assert timeout is not None
+    # Accept either a scalar or (connect, read) tuple. What we care about
+    # is that *something* is set — the exact value is a tuning knob.
+    if isinstance(timeout, tuple):
+        connect_s, read_s = timeout
+        assert 0 < connect_s <= 30
+        assert 0 < read_s <= 120
+    else:
+        assert 0 < timeout <= 120
+
+
+def test_caller_supplied_timeout_is_preserved():
+    """A caller that explicitly wants a longer read (e.g. for an
+    endpoint known to be slow) should not have its value clobbered."""
+    api, sess = _api_with_mock_session({"code": 0, "data": {}})
+    api._get_json("/slow", timeout=60)
+    _, kwargs = sess.request.call_args
+    assert kwargs["timeout"] == 60

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -90,6 +90,54 @@ def test_v2_timer_decodes_captured_d01():
     assert sub.ports[2].last_usage_dl == 0
 
 
+# --- RainPoint1ZoneTimer_V2 (HTV113FRF) -----------------------------------
+
+
+def test_v2_1zone_timer_decodes_captured_payload():
+    """HTV113FRF — single-zone mains top-up valve, paramVersion>=16 TLV.
+
+    Payload captured 2026-04-24 from the live hub while the valve was
+    idle (see api-sniffing/notes/htv113frf-probe-2026-04-24.md). Key
+    distinction from the 2-zone model: the `10#` wire prefix carries
+    NO dp_id byte per record (unlike the 2-zone's `11#`), matching the
+    HCS012ARF rain sensor packing rather than the HTV213/214 one.
+    Exercises the RainPoint1ZoneTimer_V2 subclass's HAS_DPID_PREFIX=False
+    dispatch path through the parent class.
+    """
+    from homgarapi.devices import RainPoint1ZoneTimer_V2
+
+    value = "10#E1C000DC01D80020B700000000AD00009F93020000FF0F87412F19"
+    sub = RainPoint1ZoneTimer_V2(
+        model="HTV113FRF",
+        model_code=259,
+        name="Tank Topup",
+        did=3,
+        mid=148701,
+        alerts=None,
+        address=3,
+        port_number=1,
+    )
+    sub._parse_device_specific_status_d_value(value)
+
+    # Exactly one port exists (PORT_COUNT=1 on this subclass).
+    assert set(sub.ports.keys()) == {1}
+
+    # Device-wide
+    assert sub.rf_rssi == -64            # low byte of 0xC000 as signed = -64 dBm
+    assert sub.battery_state == 1        # normal
+
+    # Port 1 — all per-port identities must be parsed via the
+    # HAS_DPID_PREFIX=False dispatch branch (which picks port 1 from the
+    # identity alone). Including multiple ports' identities to confirm
+    # the dispatch actually routes each one, not just the first.
+    p = sub.ports[1]
+    assert p.wkstate == 0                # idle (bit0 = running, 0 = off)
+    assert p.alarm == 0                  # short-form record, low-nibble=0
+    assert p.ev_time == 0
+    assert p.duration_s == 0
+    assert p.last_usage_dl == 659        # 0.1 L units → 65.9 L last cycle
+
+
 # --- RainPointRainSensor ---------------------------------------------------
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -138,6 +138,52 @@ def test_v2_1zone_timer_decodes_captured_payload():
     assert p.last_usage_dl == 659        # 0.1 L units → 65.9 L last cycle
 
 
+# --- port_label fallback rules --------------------------------------------
+
+
+def test_port_label_multi_port_with_describe():
+    sub = RainPoint2ZoneTimer_V2(
+        model="HTV213FRF", model_code=288, name="Timer", did=1,
+        mid=148701, alerts=None, address=1, port_number=2,
+        port_describe="Sprinklers|Dripline",
+    )
+    assert sub.port_label(1) == "Sprinklers"
+    assert sub.port_label(2) == "Dripline"
+
+
+def test_port_label_multi_port_without_describe_uses_port_n():
+    sub = RainPoint2ZoneTimer_V2(
+        model="HTV213FRF", model_code=288, name="Timer", did=1,
+        mid=148701, alerts=None, address=1, port_number=2,
+        port_describe="",
+    )
+    assert sub.port_label(1) == "Port 1"
+    assert sub.port_label(2) == "Port 2"
+
+
+def test_port_label_single_port_without_describe_is_empty():
+    """For 1-zone devices the helper returns "" so callers can render
+    entity names from the device label alone (HTV113FRF in the wild
+    surfaces its identity at the device level only — no portDescribe)."""
+    from homgarapi.devices import RainPoint1ZoneTimer_V2
+    sub = RainPoint1ZoneTimer_V2(
+        model="HTV113FRF", model_code=259, name="Tank Topup", did=3,
+        mid=148701, alerts=None, address=3, port_number=1,
+        port_describe="",
+    )
+    assert sub.port_label(1) == ""
+
+
+def test_port_label_single_port_with_describe_uses_describe():
+    from homgarapi.devices import RainPoint1ZoneTimer_V2
+    sub = RainPoint1ZoneTimer_V2(
+        model="HTV113FRF", model_code=259, name="Tank Topup", did=3,
+        mid=148701, alerts=None, address=3, port_number=1,
+        port_describe="Mains top-up",
+    )
+    assert sub.port_label(1) == "Mains top-up"
+
+
 # --- RainPointRainSensor ---------------------------------------------------
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,137 @@
+"""Regression tests for the TLV decoder + per-device status parsers.
+
+Inputs here are verbatim subDeviceStatus payloads captured from the
+rathga@gmail.com home's hub + sensors (see api-sniffing/captures/) — any
+change that breaks these will break the live integration.
+"""
+
+from __future__ import annotations
+
+from homgarapi.devices import (
+    RainPoint2ZoneTimer_V2,
+    RainPointRainSensor,
+    parse_tlv_d_value,
+)
+
+
+# --- TLV parser ------------------------------------------------------------
+
+
+def test_tlv_parse_with_dpid_prefix_htv213():
+    """HTV213 timer (model 288) — each record is dp_id(1) + header + payload."""
+    value = (
+        "11#17E1C20018DC0119D8001AD8001D201E2021B70000000022B7000000"
+        "0025AD000026AD0000299FD41400002A9F00000000FEFF0F102E2319"
+    )
+    recs = parse_tlv_d_value(value, has_dpid_prefix=True)
+    by_dpid_code = {(r.dp_id, r.type_code): r for r in recs}
+    # STA_RSSI — dp_id 0x17, type_code 32, 2-byte payload, low byte is signed dBm.
+    assert by_dpid_code[(0x17, 32)].payload == b"\xc2\x00"
+    # STA_BAT — dp_id 0x18, type_code 31, value 1 (normal).
+    assert by_dpid_code[(0x18, 31)].payload == b"\x01"
+    # STA_WKSTATE — dp_id 0x19 (port 1) and 0x1A (port 2), type_code 30.
+    assert by_dpid_code[(0x19, 30)].payload == b"\x00"
+    assert by_dpid_code[(0x1A, 30)].payload == b"\x00"
+    # STA_LASTUSAGE — dp_id 0x29 port 1, 4-byte payload.
+    assert by_dpid_code[(0x29, 15)].payload == b"\xd4\x14\x00\x00"
+    # Trailing extended-type record (type_code=54) exercises i15==31 path.
+    assert any(r.type_code == 54 for r in recs)
+
+
+def test_tlv_parse_no_dpid_prefix_rain_sensor():
+    """HCS012ARF rain sensor — no dp_id byte per record.
+
+    Captured value decodes to (type_code, payload):
+      (32, 0x0000)  RSSI        — low byte signed dBm = 0
+      (43, 0x0000)  STA_HOUR_RAIN   = 0.0 mm
+      (44, 0x0000)  STA_DAY_RAIN    = 0.0 mm
+      (45, 0x0000)  STA_7DAY_RAIN   = 0.0 mm
+      (31, 0x01)    STA_BAT         = 1 (normal)
+      (13, 0x00000564) STA_TOTAL_RAIN   = 1380 (0.1 mm) = 138.0 mm
+      (54, 0x16D28895) unknown — exercises i15==31 extended path
+    """
+    value = "00#E10000FD040000FD050000FD060000DC019764050000FF0F9588D216"
+    recs = parse_tlv_d_value(value, has_dpid_prefix=False)
+    type_codes = [r.type_code for r in recs]
+    assert type_codes == [32, 43, 44, 45, 31, 13, 54]
+    by_tc = {r.type_code: r for r in recs}
+    assert by_tc[31].payload == b"\x01"
+    assert by_tc[13].payload == b"\x64\x05\x00\x00"
+
+
+# --- RainPoint2ZoneTimer_V2 ------------------------------------------------
+
+
+def test_v2_timer_decodes_captured_d01():
+    value = (
+        "11#17E1C20018DC0119D8001AD8001D201E2021B70000000022B7000000"
+        "0025AD000026AD0000299FD41400002A9F00000000FEFF0F102E2319"
+    )
+    sub = RainPoint2ZoneTimer_V2(
+        model="HTV213FRF",
+        model_code=288,
+        name="Timer",
+        did=1,
+        mid=148701,
+        alerts=None,
+        address=1,
+        port_number=2,
+    )
+    sub._parse_device_specific_status_d_value(value)
+    assert sub.rf_rssi == -62  # 0xC2 low byte as signed = -62 dBm
+    assert sub.battery_state == 1
+    # Both zones idle, last-usage 0.
+    assert sub.ports[1].wkstate == 0
+    assert sub.ports[2].wkstate == 0
+    assert sub.ports[1].running is False
+    # Last usage: 0x14D4 = 5332, in 0.1 L units = 533.2 L.
+    assert sub.ports[1].last_usage_dl == 5332
+    assert sub.ports[2].last_usage_dl == 0
+
+
+# --- RainPointRainSensor ---------------------------------------------------
+
+
+def _make_rain_sensor():
+    return RainPointRainSensor(
+        model="HCS012ARF",
+        model_code=87,
+        name="Rain",
+        did=2,
+        mid=148701,
+        alerts=None,
+        address=2,
+        port_number=1,
+    )
+
+
+def test_rain_sensor_tlv_format():
+    sub = _make_rain_sensor()
+    sub._parse_status_d_value("00#E10000FD040000FD050000FD060000DC019764050000FF0F9588D216")
+    # All window counters zero, total 138.0 mm, battery normal, RSSI low byte
+    # of 0x0000 = 0 dBm (sensor apparently doesn't populate this field).
+    assert sub.rainfall_mm_hour == 0.0
+    assert sub.rainfall_mm_daily == 0.0
+    assert sub.rainfall_mm_7days == 0.0
+    assert sub.rainfall_mm_total == 138.0
+    assert sub.battery_state == 1
+    assert sub.rf_rssi == 0
+
+
+def test_rain_sensor_legacy_format():
+    """Older firmware: ``<general>;R=total(hour/24h/7d)`` in 0.1 mm units."""
+    sub = _make_rain_sensor()
+    sub._parse_status_d_value("1,-81,1;R=270(0/0/270)")
+    assert sub.rf_rssi == -81
+    assert sub.rainfall_mm_total == 27.0
+    assert sub.rainfall_mm_7days == 27.0
+    assert sub.rainfall_mm_hour == 0.0
+    assert sub.rainfall_mm_daily == 0.0
+
+
+def test_rain_sensor_bad_payload_does_not_raise():
+    """Per-sub parse errors are swallowed in the base class so one
+    mis-formatted device doesn't blow up the whole poll."""
+    sub = _make_rain_sensor()
+    sub._parse_status_d_value("garbage")  # must not raise
+    assert sub.rainfall_mm_total is None

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from homgarapi.devices import (
     RainPoint2ZoneTimer_V2,
+    RainPointDisplayHubV2,
     RainPointRainSensor,
     parse_tlv_d_value,
 )
@@ -135,3 +136,38 @@ def test_rain_sensor_bad_payload_does_not_raise():
     sub = _make_rain_sensor()
     sub._parse_status_d_value("garbage")  # must not raise
     assert sub.rainfall_mm_total is None
+
+
+# --- RainPointDisplayHubV2 (HWG023WRF) -------------------------------------
+
+
+def _make_hub_v2():
+    return RainPointDisplayHubV2(
+        model="HWG023WRF",
+        model_code=273,
+        name="Hub",
+        did=1,
+        mid=148701,
+        alerts=None,
+        subdevices=[],
+    )
+
+
+def test_hub_v2_parses_state_and_connected():
+    hub = _make_hub_v2()
+    # "state" = "<battery>,<rssi_dbm>" — captured verbatim from the API.
+    hub.set_device_status({"id": "state", "value": "0,-81"})
+    hub.set_device_status({"id": "connected", "value": "1"})
+    assert hub.battery_state == 0
+    assert hub.wifi_rssi == -81
+    assert hub.connected is True
+
+
+def test_hub_v2_ignores_null_and_malformed_values():
+    hub = _make_hub_v2()
+    hub.set_device_status({"id": "state", "value": None})       # null
+    hub.set_device_status({"id": "connected", "value": "maybe"})  # garbage
+    # Neither should raise, and neither should populate the field.
+    assert hub.battery_state is None
+    assert hub.wifi_rssi is None
+    assert hub.connected is None


### PR DESCRIPTION
Adds support for the newer RainPoint Smart+ irrigation stack that replaced
the paramVersion-2 line the library currently handles:

**New endpoints on HomgarApi**
- `refresh_token()` → `POST /auth/basic/app/token/refresh` — avoids full
  re-logins (which kick the account off its phones); closes the gap
  mentioned in the existing docstring.
- `logout()` → `POST /auth/basic/app/logOut`.
- `control_zone(hub, sub_addr, port, mode, duration)` →
  `POST /app/device/controlWorkMode`. Body shape comes from the decompiled
  RainPoint Home APK (`com.baldr.homgar.ui.presenter.C0412d0.B` and its
  twin `Z0.B`): `{deviceName, productKey, mid, addr, port, mode,
  duration, param=""}`. `mode` is `0=off | 1=manual | 2=scheduled` per the
  fragment code's toggle logic. Validated end-to-end against a live
  HWG023WRF + HTV213FRF account — the server relays the command via its
  side of Aliyun IoT Link, so no MQTT client is required.

**New devices**
- `RainPointDisplayHubV2` (modelCode 273, `HWG023WRF`) — the newer Smart+
  hub.
- `RainPoint2ZoneTimer_V2` (modelCode 288, `HTV213FRF` / `HTV214FRF`) —
  uses a new hex-packed TLV D-value format (introduced with
  `paramVersion >= 16`). The existing `RainPoint2ZoneTimer` (modelCode
  261) is left intact for older firmware.

**New decode helpers in `devices.py`**
- `parse_tlv_d_value(value)` → `List[DpRecord]`. Parses the
  `"<firmware>#<hex bytes>"` format where each record is `dpId byte` +
  either a short-form (top-bit-0) single byte or a long-form
  (top-bit-1) variable-length TLV. Algorithm matches
  `com.baldr.homgar.bean.DpDeviceStatus.analyzeDpDeviceStatus` from the
  current app.
- `ZonePortStatus` dataclass with a `.running` property for the WKSTATE
  bit-0 convention (idle=0, manual-run=33 (0x21) = bit0 set + bit5 set,
  confirmed in captures).
- Per-port labels: `HomgarSubDevice.port_label(port)` pulls from the
  API's `portDescribe` (e.g. `"Sprinklers|Dripline"`).

**Plumbing**
- `device_base_props` now captures `deviceName`, `productKey`, `iotId`,
  `sid`, and `portDescribe` from `/app/device/getDeviceByHid` responses
  so the new hub/timer classes have what they need for control.

Happy to split into smaller commits or iterate on API shape if
preferred.